### PR TITLE
增加了pip包安装的依赖文档，并更新README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 华师大上网需要进行校园网验证，验证一般是通过网页操作。然而在学校机房放置的linux服务器，不太方便打开网页进行验证，所以开发一个通过python的自动验证程序。
 
+# Preparation
+
+1. Install dependencies:
+```
+pip install -r requirements.txt
+```
+
 # Usage
 
 > usage: login.py [-h] --username USERNAME [--interval INTERVAL] [--lark LARK [LARK ...]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+urllib3==1.26.18
+requests==2.31.0
+js2py==0.74

--- a/utils/encryption.py
+++ b/utils/encryption.py
@@ -35,6 +35,7 @@ def hmac_md5(password: str, token: str) -> str:
 def get_info(username: str, password: str, ip: str, token: str) -> str:
     context = js2py.EvalJs()
     context.execute('''
+var _PADCHAR = '=';
 function encode(str, key) {
     if (str === '') return '';
     var v = s(str, true);


### PR DESCRIPTION
1. 如果使用pip安装默认版本的requests库的话，urllib3包有很大可能会报错，因此指定urllib3包的版本。
2. 同时添加了js2py的安装指令，这样一键装完依赖之后就可以直接用了。